### PR TITLE
Handle enabling/disabling of childsites on default_pages

### DIFF
--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -4,6 +4,10 @@ Changelog
 2.1 - (unreleased)
 ------------------
 
+- We don't want to enable or disable a childsite on a default page. Traverse up,
+  until a non-default page is found.
+  [thet]
+
 - Add ``current_childsite`` method to ``@@lineageutils`` view, which returns
   the current lineage subsite object or ``None``, if no lineage subsite is
   active.

--- a/src/collective/lineage/browser.py
+++ b/src/collective/lineage/browser.py
@@ -36,6 +36,7 @@ class LineageTool(BrowserView):
         # we don't want to enable/disable a childsite on a default page.
         # bend context to suitable parent.
         self.context = _get_context(context, request)
+        self.request = request
 
     @property
     def available(self):

--- a/src/collective/lineage/browser.py
+++ b/src/collective/lineage/browser.py
@@ -1,4 +1,6 @@
+from Acquisition import aq_parent
 from Products.CMFCore.utils import getToolByName
+from Products.CMFPlone.utils import isDefaultPage
 from Products.Five.browser import BrowserView
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from Products.Five.component import disableSite
@@ -21,6 +23,19 @@ _ = MessageFactory('collective.lineage')
 
 
 class LineageTool(BrowserView):
+
+    def __init__(self, context, request):
+
+        def _get_context(ctx, req):
+            if not ctx:
+                return None
+            if isDefaultPage(ctx, req):
+                return _get_context(aq_parent(ctx), req)
+            return ctx
+
+        # we don't want to enable/disable a childsite on a default page.
+        # bend context to suitable parent.
+        self.context = _get_context(context, request)
 
     @property
     def available(self):


### PR DESCRIPTION
When on a default_page, it's unlikely that someone wants to enable or disable a childsite on this default page. Actually, that was a common source of mistakes of a client and even myself.

This fix bends the context of @@lineage_tool to on of it's parents, if the original context is a default page. So far, works fine. I'm too lazy and too much in a hurry for tests in the moment, because. I hope to be able to add them later.