### PR TITLE
enable_childsite and disable_childsite utils

### DIFF
--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -4,6 +4,10 @@ Changelog
 2.1 - (unreleased)
 ------------------
 
+- Peel out ``enable_childsite`` and ``disable_childsite`` from the
+  ``lineage_tool`` view, so that it can be easily used programmatically.
+  [thet]
+
 - We don't want to enable or disable a childsite on a default page. Traverse up,
   until a non-default page is found.
   [thet]

--- a/src/collective/lineage/utils.py
+++ b/src/collective/lineage/utils.py
@@ -1,0 +1,38 @@
+from Products.Five.component import disableSite
+from collective.lineage.events import ChildSiteCreatedEvent
+from collective.lineage.events import ChildSiteRemovedEvent
+from collective.lineage.events import ChildSiteWillBeCreatedEvent
+from collective.lineage.events import ChildSiteWillBeRemovedEvent
+from collective.lineage.interfaces import IChildSite
+from five.localsitemanager import make_objectmanager_site
+from zope.component.interfaces import ISite
+from zope.event import notify
+from zope.interface import alsoProvides
+from zope.interface import noLongerProvides
+
+
+def enable_childsite(context):
+    notify(ChildSiteWillBeCreatedEvent(context))
+
+    # enable site
+    if not ISite.providedBy(context):
+        make_objectmanager_site(context)
+
+    # provide IChildSite
+    alsoProvides(context, IChildSite)
+
+    context.reindexObject(idxs=('object_provides'))
+    notify(ChildSiteCreatedEvent(context))
+
+
+def disable_childsite(context):
+    notify(ChildSiteWillBeRemovedEvent(context))
+
+    # remove local site components
+    disableSite(context)
+
+    # remove IChildSite
+    noLongerProvides(context, IChildSite)
+
+    context.reindexObject(idxs=('object_provides'))
+    notify(ChildSiteRemovedEvent(context))


### PR DESCRIPTION
Peel out ``enable_childsite`` and ``disable_childsite`` from the ``lineage_tool`` view, so that it can be easily used programmatically.

I needed this in the tests of lineage.registry.