### PR TITLE
Add 1.1.3 release, designed for upgrading pre-1.0 Lineage.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,16 +29,21 @@ Lineage works with Plone 3 and Plone 4.
 Upgrading to 2.X
 ================
 
-The `1.1.2` release of Lineage is only used to migrate your existing Lineage
-`1.1` sites up to the needed state for the new `2.0` release. Please make sure
-you upgrade any exisiting Lineage instances to `1.1.2` prior to going all the
-way to `2.0`.
+The `1.1.2` and `1.1.3` releases of Lineage are only used to migrate
+your existing sites in preparation for the Lineage `2.0` release.
+Please make sure you upgrade any exisiting Lineage instances to `1.1.2` or
+`1.1.3` prior to going all the way to `2.0`.
 
-**Note:** This `1.1.2` release will make it impossible to activate or 
-deactivate your child sites. This release only exists as a transition
-point to remove the need for `p4a.subtyper` in the next release. Existing
-child sites will continute to work, but an upgrade to `2.0` will be required
-to manage existing and new child sites.
+Use version `1.1.2` to upgrade from Lineage `1.0` or `1.1`.  Use version
+`1.1.3` to upgrade from a pre-`1.0` relase of Lineage.  (Once the upgrade
+is complete, there is no need to upgrade from version
+`1.1.2` to version `1.1.3`.)
+
+**Note:** The `1.1.2` and `1.1.3` releases will make it impossible to
+activate or deactivate your child sites. This release only exists as a
+transition point to remove the need for `p4a.subtyper` in the next release.
+Existing child sites will continute to work, but an upgrade to `2.0` will be
+required to manage existing and new child sites.
 
 Useful links
 ============

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os
 from setuptools import setup, find_packages
 
-version = '1.1.2'
+version = '1.1.3'
 
 
 def read(*rnames):

--- a/src/collective/lineage/profiles/removep4a/componentregistry.xml
+++ b/src/collective/lineage/profiles/removep4a/componentregistry.xml
@@ -2,7 +2,7 @@
 <componentregistry>
   <utilities>
     <utility remove="True"
-        interface="p4a.subtyper.interfaces.IFolderishContentTypeDescriptor"
+        interface="p4a.subtyper.interfaces.IPortalTypedFolderishDescriptor"
         name="collective.lineage.childsite"/>
   </utilities>
 </componentregistry>

--- a/src/collective/lineage/profiles/uninstall/componentregistry.xml
+++ b/src/collective/lineage/profiles/uninstall/componentregistry.xml
@@ -2,7 +2,7 @@
 <componentregistry>
   <utilities>
     <utility remove="True"
-        interface="p4a.subtyper.interfaces.IFolderishContentTypeDescriptor"
+        interface="p4a.subtyper.interfaces.IPortalTypedFolderishDescriptor"
         name="collective.lineage.childsite"/>
   </utilities>
 </componentregistry>


### PR DESCRIPTION
This should fix the utility unregistration for sites running Lineage 0.6.1 and earlier.