### PR TITLE
Depend on Products.CMFPlone instead of Plone to not fetch unnecessary dependencies

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 2.2 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Depend on ``Products.CMFPlone`` instead of ``Plone`` to not fetch unnecessary dependencies.
+  [thet]
 
 
 2.1 (2016-10-03)

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     zip_safe=False,
     install_requires=[
         'setuptools',
-        'Plone',
+        'Products.CMFPlone',
     ],
     extras_require={
         'test': [


### PR DESCRIPTION
5.1-latest couldn't be installed because Plone 5.1 doesn't exist yet. Also, this fetches Archetypes among other dependencies, which are not strictly necessary in Plone 5.1.