### PR TITLE
Remove unused utility method parent_site.

### DIFF
--- a/news/+remove-parent-site.breaking.rst
+++ b/news/+remove-parent-site.breaking.rst
@@ -1,0 +1,5 @@
+Remove unused utility method parent_site.
+
+This could break other people's code, but this method is not used anywhere in
+collective.lineage.
+[thet]

--- a/src/collective/lineage/tests/test_utils.py
+++ b/src/collective/lineage/tests/test_utils.py
@@ -1,22 +1,19 @@
-from .. import testing
 from collective.lineage import utils
+from collective.lineage.testing import LineageTestCase
 from plone.browserlayer import utils as layer_utils
-from zope import component
-from zope import interface
-from zope.site.hooks import site as site_hook
-
-import unittest
+from zope.component import getSiteManager
+from zope.interface import Interface
 
 PROJECTNAME = "collective.lineage"
 
 
-class IChildSiteLayer(interface.Interface):
+class IChildSiteLayer(Interface):
     """
     An example browser layer for a child site.
     """
 
 
-class UtilsTestCase(testing.LineageTestCase):
+class UtilsTestCase(LineageTestCase):
     """
     Test the Lineage utility functions.
     """
@@ -44,7 +41,7 @@ class UtilsTestCase(testing.LineageTestCase):
         layer_utils.register_layer(
             IChildSiteLayer,
             "collective.lineage.childsite.layer",
-            site_manager=component.getSiteManager(self.childsite),
+            site_manager=getSiteManager(self.childsite),
         )
 
         self.assertFalse(
@@ -56,14 +53,3 @@ class UtilsTestCase(testing.LineageTestCase):
             IChildSiteLayer.providedBy(self.portal.REQUEST),
             "Child site browser layer not applied to the request",
         )
-
-    def test_parent_site_on_siteroot(self):
-        site = utils.parent_site()
-        self.assertEqual(site, self.portal)
-
-    @unittest.skip("Currently fails, due to `_find_site` always going for aq_parent.")
-    def test_parent_site_on_childsite(self):
-        utils.enable_childsite(self.childsite)
-        with site_hook(self.childsite):
-            site = utils.parent_site()
-        self.assertEqual(site, self.childsite)

--- a/src/collective/lineage/utils.py
+++ b/src/collective/lineage/utils.py
@@ -1,13 +1,10 @@
-from Acquisition import aq_parent
 from collective.lineage.events import ChildSiteCreatedEvent
 from collective.lineage.events import ChildSiteRemovedEvent
 from collective.lineage.events import ChildSiteWillBeCreatedEvent
 from collective.lineage.events import ChildSiteWillBeRemovedEvent
 from collective.lineage.interfaces import IChildSite
 from five.localsitemanager import make_objectmanager_site
-from plone.base.interfaces import IPloneSiteRoot
 from Products.Five.component import disableSite
-from zope.component.hooks import getSite
 from zope.component.interfaces import ISite
 from zope.event import notify
 from zope.interface import alsoProvides
@@ -39,19 +36,3 @@ def disable_childsite(context):
 
     context.reindexObject(idxs=("object_provides"))
     notify(ChildSiteRemovedEvent(context))
-
-
-def parent_site():
-    def _find_site(ctx):
-        # First, stop at IPloneSiteRoot
-        if IPloneSiteRoot.providedBy(ctx):
-            return ctx
-        # Then walk up
-        ctx = aq_parent(ctx)
-        if IChildSite.providedBy(ctx):
-            return ctx
-        return _find_site(ctx)
-
-    # Start at current site
-    site = _find_site(getSite())
-    return site


### PR DESCRIPTION
This could break other people's code, but this method is not used anywhere in collective.lineage.